### PR TITLE
Allow environment variables for vCenter URL and cloudadmin password

### DIFF
--- a/CloudAdminGroup-Manage.ps1
+++ b/CloudAdminGroup-Manage.ps1
@@ -5,8 +5,19 @@
 
 clear
 # Define the vCenter server URL
-$vCenterServer = Read-Host -Prompt "Please input the VC URL (EX: vcenter.sddc-xx-xxx-xxx-xxx.vmwarevmc.com)"
-$pass = Read-Host -Prompt "Enter the Cloudadmin@vmc.local password"
+if ( $null -eq $env:VMC_VCENTER_URL) {
+    $vCenterServer = Read-Host -Prompt "Please input the VC URL (EX: vcenter.sddc-xx-xxx-xxx-xxx.vmwarevmc.com)"
+}
+else {
+    $vCenterServer = $env:VMC_VCENTER_URL
+}
+
+if ( $null -eq $env:VMC_VCENTER_PASSWORD) {
+    $pass = Read-Host -Prompt "Enter the Cloudadmin@vmc.local password"
+}
+else {
+    $pass = $env:VMC_VCENTER_PASSWORD
+}
 
 
 clear

--- a/CloudAdminGroup-Manage.ps1
+++ b/CloudAdminGroup-Manage.ps1
@@ -3,7 +3,7 @@
 # USAGE: Run Powershell script, select the option you want from the given list
 # RESULT: Provides the current groups in CloudAdminGroup, and allows for ADD/REMOVE operations to the CloudAdminGroup
 
-clear
+Clear-Host
 # Define the vCenter server URL
 if ( $null -eq $env:VMC_VCENTER_URL) {
     $vCenterServer = Read-Host -Prompt "Please input the VC URL (EX: vcenter.sddc-xx-xxx-xxx-xxx.vmwarevmc.com)"
@@ -20,7 +20,7 @@ else {
 }
 
 
-clear
+Clear-Host
 
 $server = Connect-VIServer -Server $vCenterServer -User cloudadmin@vmc.local -Password $pass
 Write-Host Connected to the vCenter Server successfully.`n
@@ -108,7 +108,7 @@ while (-not $exitRequested) {
             Read-Host "Press ENTER to continue"
         }
     }
-    clear
+    Clear-Host
 }
 Disconnect-VIServer -Confirm:$false
 Write-Host `nCleaned up vCenter Server Connection.


### PR DESCRIPTION
Changes script to accept $env:VMC_VCENTER_URL and $env:VMC_VCENTER_PASSWORD env variables. If those env variables are populated, the script uses them. If they are not populated, the script prompts the user for input as it did in the original version. This is really only useful for running the script repeatedly for testing or documentation purposes. That's what I'm doing now and I got tired of pasting it in every time.

The other change converts `clear` to `Clear-Host` because I didn't want to keep seeing VS Code complain.